### PR TITLE
Fix insecure SECRET_KEY default

### DIFF
--- a/app_config.py
+++ b/app_config.py
@@ -1,6 +1,8 @@
 import os
+import secrets
 
-SECRET_KEY = os.environ.get('SECRET_KEY', 'string')
+# SECURITY: fall back to a random key if SECRET_KEY env variable is missing
+SECRET_KEY = os.environ.get('SECRET_KEY') or secrets.token_hex(32)
 SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL", "sqlite:///blog.db")
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 MAIL_SERVER = 'smtp.gmail.com'

--- a/tests/test_secret_key.py
+++ b/tests/test_secret_key.py
@@ -1,0 +1,10 @@
+# NOTE: Not fully tested with production setup due to environment limits
+import unittest
+import app_config
+
+class TestSecretKey(unittest.TestCase):
+    def test_secret_key_not_default(self):
+        self.assertNotEqual(app_config.SECRET_KEY, 'string')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- use a random SECRET_KEY when environment variable missing
- add regression test for SECRET_KEY

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6864789a2fbc832b8f741537967c6f48