### PR TITLE
Fix logging bug in post editing API

### DIFF
--- a/logs/functions.py
+++ b/logs/functions.py
@@ -88,15 +88,17 @@ def log_api_post_edition(requested_post, changes_json, requesting_user):
     changes = []
     for key in changes_json:
         if getattr(requested_post, key) != changes_json[key] and any(str(changes_json[key]).strip()):
-            new_change = f"{key.title() if key != 'img_url' else 'Image URL'}:" \
-                         f" {requested_post[key]} -> {changes_json[key]}"
+            new_change = (
+                f"{key.title() if key != 'img_url' else 'Image URL'}: "
+                f"{getattr(requested_post, key)} -> {changes_json[key]}"
+            )
             changes.append(new_change)
     changes_description = '<br><br>'.join(changes)
     if any(changes):
         new_log = Log(user=requesting_user, user_name=requesting_user.name, category='api_request',
                       description=f"{requesting_user.name} edited a post via an API request.<br>"
                                   f'Post ID: {requested_post.id}<br><br>'
-                                  f'Changes:<br><br>{changes_description}', user_email=requesting_user.emai,
+                                  f'Changes:<br><br>{changes_description}', user_email=requesting_user.email,
                       date=generate_date())
         db.session.add(new_log)
         db.session.commit()

--- a/tests/test_log_api_post_edition.py
+++ b/tests/test_log_api_post_edition.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from logs.functions import log_api_post_edition
+
+class DummySession:
+    def __init__(self):
+        self.add_called = False
+        self.commit_called = False
+    def add(self, obj):
+        self.add_called = True
+    def commit(self):
+        self.commit_called = True
+
+class DummyDB:
+    def __init__(self):
+        self.session = DummySession()
+
+dummy_db = DummyDB()
+
+def test_log_api_post_edition(monkeypatch):
+    class DummyKey:
+        edit_post = 0
+    class DummyUser:
+        name = 'tester'
+        email = 'tester@example.com'
+    class DummyPost:
+        id = 1
+        title = 'old title'
+        subtitle = 'old subtitle'
+        body = 'body'
+        img_url = ''
+
+    monkeypatch.setattr('logs.functions.load_api_key', lambda user: DummyKey())
+    monkeypatch.setattr('logs.functions.db', dummy_db)
+
+    log_api_post_edition(DummyPost(), {'title': 'new title'}, DummyUser())
+
+    assert dummy_db.session.add_called
+    assert dummy_db.session.commit_called


### PR DESCRIPTION
## Summary
- fix attribute access when logging API post edits
- correct typo in logging user email
- add regression test for log_api_post_edition

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_login')*

------
https://chatgpt.com/codex/tasks/task_e_68647b11bfc4832b9619d40d569e19d9