### PR TITLE
Fix token validation bypass

### DIFF
--- a/users_manager/routes.py
+++ b/users_manager/routes.py
@@ -111,7 +111,9 @@ def delete_user(user_id, token=None):
     if user:
         if user.admin:
             if token:
-                load_token(token=token, salt='remove-auth')
+                response = load_token(token=token, salt='remove-auth')
+                if response:
+                    return response
             else:
                 return redirect(url_for('verification.authorization', user_id=user_id))
         form = DeleteForm()

--- a/verification_manager/handle_verification.py
+++ b/verification_manager/handle_verification.py
@@ -14,19 +14,22 @@ from extensions import db
 
 
 def load_token(token, salt, redirect_to='home.home_page'):
-    """Checks whether a token is valid or redirects the user."""
+    """Checks whether a token is valid or returns a redirect response."""
     try:
-        confirmation = serializer.loads(token, salt=salt, max_age=TOKEN_AGE)
+        serializer.loads(token, salt=salt, max_age=TOKEN_AGE)
     except SignatureExpired:
         flash("The token is expired, please try again.")
         return redirect(url_for(redirect_to))
     except BadTimeSignature:
         flash("Incorrect token, please try again.")
         return redirect(url_for(redirect_to))
+    return None
 
 
 def handle_email_verification(token, email):
-    load_token(token=token, salt='email-verify', redirect_to='register')
+    response = load_token(token=token, salt='email-verify', redirect_to='register')
+    if response:
+        return response
     user = User.query.filter_by(email=email).first()
     if user:
         if not user.confirmed_email:
@@ -46,7 +49,9 @@ def handle_email_verification(token, email):
 
 
 def handle_forgot_password(token, user, new_password):
-    load_token(token=token, salt='forget-password', redirect_to='login')
+    response = load_token(token=token, salt='forget-password', redirect_to='login')
+    if response:
+        return response
     if user:
         new_password = generate_password_hash(password=new_password,
                                               method='pbkdf2:sha256', salt_length=8)
@@ -64,7 +69,9 @@ def handle_forgot_password(token, user, new_password):
 
 
 def handle_support_confirmation(token, email):
-    load_token(token=token, salt='support-verify')
+    response = load_token(token=token, salt='support-verify')
+    if response:
+        return response
     if not any(email):
         return abort(400)
     config_data = get_data()
@@ -82,7 +89,9 @@ def handle_support_confirmation(token, email):
 
 
 def make_user_administrator(token, user, reason):
-    load_token(token, salt='make-auth')
+    response = load_token(token, salt='make-auth')
+    if response:
+        return response
     if user:
         try:
             user.author = False
@@ -102,7 +111,9 @@ def make_user_administrator(token, user, reason):
 
 
 def remove_administrator(token, user, reason):
-    load_token(token=token, salt='remove-auth')
+    response = load_token(token=token, salt='remove-auth')
+    if response:
+        return response
     if user:
         try:
             user.admin = False
@@ -121,7 +132,9 @@ def remove_administrator(token, user, reason):
 
 
 def handle_deletion_decision(decision, requested_user, token):
-    load_token(token=token, salt='deletion_request')
+    response = load_token(token=token, salt='deletion_request')
+    if response:
+        return response
     requested_report = DeletionReport.query.filter_by(user=requested_user).first()
     if requested_report:
         if decision == 'approved':
@@ -156,7 +169,9 @@ def handle_rejected_deletion_request(requested_user):
 
 
 def subscription_verification_handling(requested_subscription, token):
-    load_token(token=token, salt='subscription-verify')
+    response = load_token(token=token, salt='subscription-verify')
+    if response:
+        return response
     if requested_subscription:
         if not requested_subscription.active:
             requested_subscription.active = True
@@ -171,7 +186,9 @@ def subscription_verification_handling(requested_subscription, token):
 
 
 def unsubscription_verification_handling(requested_subscription, token, reason, explanation):
-    load_token(token=token, salt='unsubscription-verify')
+    response = load_token(token=token, salt='unsubscription-verify')
+    if response:
+        return response
     if requested_subscription:
         if requested_subscription.active:
             requested_subscription.active = False

--- a/verification_manager/routes.py
+++ b/verification_manager/routes.py
@@ -34,7 +34,9 @@ def generate_forget():
 
 @verification.route('/handle-forget/<token>', methods=['GET', 'POST'])
 def forget_password(token):
-    load_token(token=token, salt='forget-password', redirect_to='login_system.login')
+    response = load_token(token=token, salt='forget-password', redirect_to='login_system.login')
+    if response:
+        return response
     email = request.args.get('email')
     form = ForgetPasswordForm()
     user = User.query.filter_by(email=email).first()
@@ -58,7 +60,9 @@ def handle_support_confirmation(token):
 def handle_new_admin(token):
     if get_admin_count() > 0:
         admin_redirect()
-    load_token(token, salt='make-auth')
+    response = load_token(token, salt='make-auth')
+    if response:
+        return response
     try:
         user_id = int(request.args.get('user_id'))
     except (TypeError, ValueError):
@@ -82,7 +86,9 @@ def handle_new_admin(token):
 @verification.route('/admin-remove/<token>', methods=['GET', 'POST'])
 @admin_only
 def handle_admin_removal(token):
-    load_token(token=token, salt='remove-auth')
+    response = load_token(token=token, salt='remove-auth')
+    if response:
+        return response
     try:
         user_id = int(request.args.get('user_id'))
     except (TypeError, ValueError):


### PR DESCRIPTION
## Summary
- return early when tokens are invalid so requests cannot bypass verification
- guard all token checks with the new response handling

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6864827634ac832b9de99e566d1c169c